### PR TITLE
Feat/improve-loadInvetory-timings

### DIFF
--- a/BotLooter/Steam/SteamWeb.cs
+++ b/BotLooter/Steam/SteamWeb.cs
@@ -27,7 +27,7 @@ public class SteamWeb
         
         do
         {
-            var inventoryResponse = await GetInventoryItemsWithDescriptions(appId, contextId, 10000, true, startAssetId);
+            var inventoryResponse = await GetInventoryItemsWithDescriptions(appId, contextId, 5000, true, startAssetId);
 
             if (inventoryResponse is null)
             {
@@ -52,11 +52,6 @@ public class SteamWeb
                 }
             }
 
-            if (startAssetId is not null)
-            {
-                await Task.Delay(TimeSpan.FromSeconds(2));
-            }
-
         } while (startAssetId is not null);
 
         return (descriptions, assets);
@@ -65,7 +60,7 @@ public class SteamWeb
     public async Task<GetInventoryItemsWithDescriptionsResponse?> GetInventoryItemsWithDescriptions(
         string appId, 
         string contextId,
-        int count = 10000,
+        int count = 5000,
         bool getDescriptions = true,
         string? startAssetId = null)
     {


### PR DESCRIPTION
Удалена ненужная пауза в 2s между запросами, т.к. она не нужна, если запросы разные.
Если мы делает один и тот же запрос, только в этом случае срабатывает лимит в 2s.

Помимо этого снижено количество загружаемых предметов с 10к до 5к, чтобы убедиться, что описания наверняка были загружены. Учитывая что паузы в 2 секунды нет, разница загрузки запросами между 10к и 5к не будет заметна.