### PR TITLE
Feat/decrease-delay-inventory-empty-seconds

### DIFF
--- a/BotLooter/Resources/Configuration.cs
+++ b/BotLooter/Resources/Configuration.cs
@@ -11,7 +11,7 @@ public class Configuration
     public string SteamSessionsDirectoryPath { get; set; } = "";
     public string ProxiesFilePath { get; set; } = "proxies.txt";
     public int DelayBetweenAccountsSeconds { get; set; } = 30;
-    public int DelayInventoryEmptySeconds { get; set; } = 10;
+    public int DelayInventoryEmptySeconds { get; set; } = 0;
     public bool AskForApproval { get; set; } = true;
     public bool ExitOnFinish { get; set; } = false;
     public int LootThreadCount { get; set; } = 1;

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ BotLooter.Config.json
   "ProxiesFilePath": "proxies.txt",
   
   "DelayBetweenAccountsSeconds": 30,
-  "DelayInventoryEmptySeconds": 10,
+  "DelayInventoryEmptySeconds": 0,
   
   "AskForApproval": true,
   "ExitOnFinish": false,


### PR DESCRIPTION
Учитывая, что нам больше нет необходимости(https://github.com/SmallTailTeam/BotLooter/pull/21) ждать откат рейтлимита инвентаря, имеет смысл снизить DelayInventoryEmptySeconds для ускорения лутания.

Я бы предпочёл совсем удалить этот параметр за ненадобностью, но возможно для кого-то этот параметр необходим.