### PR TITLE
Fix/update-sendTradeOfferPolicy

### DIFF
--- a/BotLooter/Looting/LootClient.cs
+++ b/BotLooter/Looting/LootClient.cs
@@ -26,7 +26,13 @@ public class LootClient
         _steamWeb = steamWeb;
 
         _sendTradeOfferPolicy = Policy
-            .HandleResult<RestResponse<SendTradeOfferResponse>>(res => res.StatusCode == HttpStatusCode.InternalServerError)
+            .HandleResult<RestResponse<SendTradeOfferResponse>>(res => {
+                if (res.StatusCode != HttpStatusCode.InternalServerError) {
+                    return false;
+                }
+
+                return res.Content?.ToLower().Contains("please try again later") ?? false;
+            })
             .WaitAndRetryAsync(3, _ => TimeSpan.FromSeconds(10));
     }
 


### PR DESCRIPTION
Похоже, Steam часто отправляет ошибку 500 не только в случаях, когда проблемы с серверами, но и в других случаях.

Например, при ошибке 26, когда предметы где-то зависли и повторные попытки их отправить не помогают:
https://steamerrors.com/26

Поэтому предлагаю фильтровать возможность повторного запроса в случаях, когда у стима проблемы с серверами, в частности, когда текст ошибки сам предлагает попробовать сделать запрос позже.