### PR TITLE
feat/load-inventory-like-steamweb

### DIFF
--- a/BotLooter/Steam/Contracts/Responses/InventoryResponse.cs
+++ b/BotLooter/Steam/Contracts/Responses/InventoryResponse.cs
@@ -120,7 +120,7 @@ public class MarketAction
     public string Name { get; set; }
 }
 
-public class Response
+public class InventoryResponse
 {
     [JsonProperty("assets")]
     public List<Asset>? Assets { get; set; }
@@ -135,13 +135,10 @@ public class Response
     public string? LastAssetId { get; set; }
 
     [JsonProperty("more_items")]
-    public bool? MoreItems { get; set; }
-}
+    public int? MoreItems { get; set; }
 
-public class GetInventoryItemsWithDescriptionsResponse
-{
-    [JsonProperty("response")]
-    public Response Response { get; set; }
+    [JsonProperty("success")]
+    public int Success { get; set; }
 }
 
 public class Tag


### PR DESCRIPTION
В этом PR предлагаю вернуться к загрузке инвентаря старым способом, чтобы повторять официальное поведение.

Помимо прочего, я изучил работу лимитов эндпоинта и сделал отправку запросов в соответствии с текущими лимитами, а именно:

- Между разными запросами (пагинация) нет лимитов на загрузку личного инвентаря
- Между одинаковыми запросами существует лимит на отправку запросов - не чаще 1 раза в 4с.

Таким образом инвентарь должен загружаться быстро, но если будут ошибки запросов - делаем повторы, с паузами 4с.

В шапку класса вынес переменную `MaxItemsPerInventoryRequest` для регулирования максимального количества загружаемых предметов за 1 запрос. Исходя из моих тестов, стабильно можно загружать до 5000 предметов за 1 запрос, но по умолчанию на всякий случай оставил 2000.

Оставил проверку на то, существуют ли описания предметов, если сами предметы в теле сообщения есть.
Не уверен что она необходима, но и ничего не мешает её оставить.

