### PR TITLE
feat/minor-changes-for-httpclient-configure 

### DIFF
--- a/BotLooter/Resources/LocalRestClientProvider.cs
+++ b/BotLooter/Resources/LocalRestClientProvider.cs
@@ -15,8 +15,15 @@ public class LocalRestClientProvider : IRestClientProvider
         {
             UserAgent =
                 "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36",
-            FollowRedirects = false
-        }, configureSerialization: b => b.UseNewtonsoftJson());
+            FollowRedirects = false,
+            MaxTimeout = 60000
+        }, 
+        configureDefaultHeaders: h => 
+        {
+            h.Add("Accept", "*/*");
+            h.Add("Connection", "keep-alive");
+        },
+        configureSerialization: b => b.UseNewtonsoftJson());
     }
 
     public RestClient Provide()

--- a/BotLooter/Resources/ProxyRestClientProvider.cs
+++ b/BotLooter/Resources/ProxyRestClientProvider.cs
@@ -59,8 +59,15 @@ public class ProxyRestClientProvider : IRestClientProvider
                 UserAgent =
                     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36",
                 Proxy = proxy,
-                FollowRedirects = false
-            }, configureSerialization: b => b.UseNewtonsoftJson());
+                FollowRedirects = false,
+                MaxTimeout = 60000
+            }, 
+            configureDefaultHeaders: h => 
+            {
+                h.Add("Accept", "*/*");
+                h.Add("Connection", "keep-alive");
+            },
+            configureSerialization: b => b.UseNewtonsoftJson());
 
             proxiedClients.Add(restClient);
         }

--- a/BotLooter/Steam/SteamUserSession.cs
+++ b/BotLooter/Steam/SteamUserSession.cs
@@ -59,8 +59,6 @@ public class SteamUserSession
         }
         
         var request = new RestRequest("https://store.steampowered.com/account", Method.Head);
-        request.AddHeader("Accept", "*/*");
-
 
         var response = await WebRequest(request);
         

--- a/BotLooter/Steam/SteamWeb.cs
+++ b/BotLooter/Steam/SteamWeb.cs
@@ -139,7 +139,6 @@ public class SteamWeb
     public async Task<string> GetHelpWhyCantITradeTime()
     {
         var request = new RestRequest("https://help.steampowered.com/ru/wizard/HelpWhyCantITrade");
-        request.AddHeader("Accept", "*/*");
 
         var response = await _userSession.WebRequest(request);
 


### PR DESCRIPTION
Добавлен таймаут для http запросов (60с). На самом деле достаточно и 10с, но чтобы наверняка, поставил больше.

Добавлен заголовок `Accept: */*` по умолчанию и удален из кода там, где повторяется.
Добавлен заголовок `Connection: keep-alive`, т.к. почему-то он отсутствует в запросах, хоть и соединения переиспользуются.

