### PR TITLE
fixed load empty inventory

### DIFF
--- a/BotLooter/Steam/SteamWeb.cs
+++ b/BotLooter/Steam/SteamWeb.cs
@@ -33,7 +33,7 @@ public class SteamWeb
                 }
 
                 // bad response
-                if (res.Data.Assets is not null && res.Data.Descriptions is null)
+                if (res.Data.TotalInventoryCount != 0 && res.Data.Assets is not null && res.Data.Descriptions is null)
                 {
                     return true;
                 }


### PR DESCRIPTION
Когда инвентарь пустой, нам не возвращаются поля `assets` и `descriptions`. Это могло приводить к ненужной повторной загрузке пустых инвентарей.
