### PR TITLE
Add support for secrets without deviceid

### DIFF
--- a/BotLooter/Resources/SteamAccountCredentials.cs
+++ b/BotLooter/Resources/SteamAccountCredentials.cs
@@ -130,7 +130,7 @@ public class SteamAccountCredentials
         return loadedCount;
     }
     
-    private static string GetDeviceId(string steamId)
+    public static string GetDeviceId(string steamId)
     {
         var bytes = Encoding.UTF8.GetBytes(steamId);
         var hashBytes = SHA1.HashData(bytes);
@@ -218,9 +218,9 @@ public class SteamAccountCredentials
                     continue;
                 }
 
-                if (secret is not { SharedSecret: not null, IdentitySecret: not null, DeviceID: not null })
+                if (secret is not { SharedSecret: not null, IdentitySecret: not null })
                 {
-                    Log.Logger.Warning("В секретном файле отсутствует shared_secret, identity_secret или device_id: {Path}", filePath);
+                    Log.Logger.Warning("В секретном файле отсутствует shared_secret или identity_secret: {Path}", filePath);
                     continue;
                 }
 

--- a/BotLooter/Steam/SteamUserSession.cs
+++ b/BotLooter/Steam/SteamUserSession.cs
@@ -5,6 +5,7 @@ using Polly.Retry;
 using RestSharp;
 using SteamAuth;
 using SteamSession;
+using static BotLooter.Resources.SteamAccountCredentials;
 
 namespace BotLooter.Steam;
 
@@ -105,6 +106,11 @@ public class SteamUserSession
                 SteamLoginSecure = steamLoginSecure,
                 SteamID = SteamId.Value
             };
+
+            if (Credentials.SteamGuardAccount.DeviceID is null)
+            {
+                Credentials.SteamGuardAccount.DeviceID = GetDeviceId(SteamId.Value.ToString());
+            }
             
             return (true, "Авторизовался");
         }


### PR DESCRIPTION
Как известно, `maFile` не имеет строгую структуру. Из-за этого часто можно увидеть файлы без нужных нам полей, например без deviceid.

В подобном случае мы получим что-то вроде:
![telegram-cloud-photo-size-2-5305796748742089797-x](https://github.com/SmallTailTeam/BotLooter/assets/47674424/b8c0918d-3d8d-4767-b246-a10e873c9ee6)

Т.к. мы можем генерировать `deviceid` самостоятельно, можно игнорировать его отсутствие в мафайле.