### PR TITLE
fix: update confirmations retry delay to match steam limits

### DIFF
--- a/BotLooter/Steam/SteamUserSession.cs
+++ b/BotLooter/Steam/SteamUserSession.cs
@@ -32,7 +32,7 @@ public class SteamUserSession
 
         _acceptConfirmationPolicy = Policy
             .HandleResult<bool>(x => x is false)
-            .WaitAndRetryAsync(5, _ => TimeSpan.FromSeconds(5));
+            .WaitAndRetryAsync(5, _ => TimeSpan.FromSeconds(10));
     }
 
     public async ValueTask<(bool IsSession, string Message)> TryEnsureSession()


### PR DESCRIPTION
лимиты на загрузку страницы с подтверждениями - 10с для ip