### PR TITLE
fix: reduce MaxItemsPerInventoryRequest to 1000

### DIFF
--- a/BotLooter/Steam/SteamWeb.cs
+++ b/BotLooter/Steam/SteamWeb.cs
@@ -15,7 +15,7 @@ public class SteamWeb
     private readonly SteamUserSession _userSession;
     private readonly IHtmlParser _htmlParser;
 
-    private readonly int MaxItemsPerInventoryRequest = 2000;
+    private readonly int MaxItemsPerInventoryRequest = 1000;
 
     private readonly AsyncRetryPolicy<RestResponse<InventoryResponse?>> _getInventoryPolicy;
 


### PR DESCRIPTION
due to Steam changes from 28.05.25, max count now is 1000
grater values will cause BadRequest (400) exceptions