### PR TITLE
feat: update Sec-Fetch-* headers for consistency

### DIFF
--- a/BotLooter/Resources/LocalRestClientProvider.cs
+++ b/BotLooter/Resources/LocalRestClientProvider.cs
@@ -21,7 +21,7 @@ public class LocalRestClientProvider : IRestClientProvider
             configureDefaultHeaders: h => 
             {
                 h.Add("Accept", "application/json, text/plain, */*");
-                h.Add("Sec-Fetch-Site", "cross-site");
+                h.Add("Sec-Fetch-Site", "same-origin");
                 h.Add("Sec-Fetch-Mode", "cors");
                 h.Add("Sec-Fetch-Dest", "empty");
             },

--- a/BotLooter/Resources/ProxyRestClientProvider.cs
+++ b/BotLooter/Resources/ProxyRestClientProvider.cs
@@ -68,7 +68,7 @@ public class ProxyRestClientProvider : IRestClientProvider
                 configureDefaultHeaders: h => 
                 {
                     h.Add("Accept", "application/json, text/plain, */*");
-                    h.Add("Sec-Fetch-Site", "cross-site");
+                    h.Add("Sec-Fetch-Site", "same-origin");
                     h.Add("Sec-Fetch-Mode", "cors");
                     h.Add("Sec-Fetch-Dest", "empty");
                 },

--- a/BotLooter/Steam/SteamUserSession.cs
+++ b/BotLooter/Steam/SteamUserSession.cs
@@ -56,6 +56,10 @@ public class SteamUserSession
         
         var request = new RestRequest("https://store.steampowered.com/account", Method.Head);
 
+        request.AddOrUpdateHeader("Sec-Fetch-Dest", "document");
+        request.AddOrUpdateHeader("Sec-Fetch-Mode", "navigate");
+        request.AddOrUpdateHeader("Sec-Fetch-Site", "none");
+
         var response = await WebRequest(request);
         
         return response.ResponseUri is not null && !response.ResponseUri.AbsolutePath.StartsWith("/login");

--- a/BotLooter/Steam/SteamWeb.cs
+++ b/BotLooter/Steam/SteamWeb.cs
@@ -146,6 +146,10 @@ public class SteamWeb
     {
         var request = new RestRequest("https://help.steampowered.com/ru/wizard/HelpWhyCantITrade");
 
+        request.AddOrUpdateHeader("Sec-Fetch-Dest", "document");
+        request.AddOrUpdateHeader("Sec-Fetch-Mode", "navigate");
+        request.AddOrUpdateHeader("Sec-Fetch-Site", "none");
+
         var response = await _userSession.WebRequest(request);
 
         if (response.Content is null)


### PR DESCRIPTION
Updates `Sec-Fetch-*` headers for more natural way.

But, if this is too much overhead, better to drop this headers entirely across all app.

Benefits of them - better authenticy with browser, but is this required?