### PR TITLE
feat: rid of browser headers

### DIFF
--- a/BotLooter/Resources/LocalRestClientProvider.cs
+++ b/BotLooter/Resources/LocalRestClientProvider.cs
@@ -18,12 +18,9 @@ public class LocalRestClientProvider : IRestClientProvider
                 o.FollowRedirects = false;
                 o.MaxTimeout = (int)TimeSpan.FromSeconds(60).TotalMilliseconds;
             },
-            configureDefaultHeaders: h => 
+            configureDefaultHeaders: h =>
             {
                 h.Add("Accept", "application/json, text/plain, */*");
-                h.Add("Sec-Fetch-Site", "cross-site");
-                h.Add("Sec-Fetch-Mode", "cors");
-                h.Add("Sec-Fetch-Dest", "empty");
             },
             configureSerialization: b => b.UseNewtonsoftJson());
     }

--- a/BotLooter/Resources/LocalRestClientProvider.cs
+++ b/BotLooter/Resources/LocalRestClientProvider.cs
@@ -21,6 +21,7 @@ public class LocalRestClientProvider : IRestClientProvider
             configureDefaultHeaders: h =>
             {
                 h.Add("Accept", "application/json, text/plain, */*");
+                h.Add("Accept-Language", "en-US,en;q=0.9");
             },
             configureSerialization: b => b.UseNewtonsoftJson());
     }

--- a/BotLooter/Resources/ProxyRestClientProvider.cs
+++ b/BotLooter/Resources/ProxyRestClientProvider.cs
@@ -65,12 +65,9 @@ public class ProxyRestClientProvider : IRestClientProvider
                     o.FollowRedirects = false;
                     o.MaxTimeout = (int)TimeSpan.FromSeconds(60).TotalMilliseconds;
                 },
-                configureDefaultHeaders: h => 
+                configureDefaultHeaders: h =>
                 {
                     h.Add("Accept", "application/json, text/plain, */*");
-                    h.Add("Sec-Fetch-Site", "cross-site");
-                    h.Add("Sec-Fetch-Mode", "cors");
-                    h.Add("Sec-Fetch-Dest", "empty");
                 },
                 configureSerialization: b => b.UseNewtonsoftJson());
 

--- a/BotLooter/Resources/ProxyRestClientProvider.cs
+++ b/BotLooter/Resources/ProxyRestClientProvider.cs
@@ -68,6 +68,7 @@ public class ProxyRestClientProvider : IRestClientProvider
                 configureDefaultHeaders: h =>
                 {
                     h.Add("Accept", "application/json, text/plain, */*");
+                    h.Add("Accept-Language", "en-US,en;q=0.9");
                 },
                 configureSerialization: b => b.UseNewtonsoftJson());
 


### PR DESCRIPTION
opposite to https://github.com/SmallTailTeam/BotLooter/pull/88

don't really think that browser headers really needed here, as well, not every browser headers were emulated previously

also, added `Accept-Language` header for consistency